### PR TITLE
Release of new version 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 env:
   global:
     - PATH="$HOME/.composer/vendor/bin:$PATH"
-    - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
+    - SYMFONY_DEPRECATIONS_HELPER=max[self]=0
     - TARGET=test
 
 stages:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,35 @@
+11/06/2019 18:48  2.2.0  Internal code refactoring
+f74947c [TEST] Use better default locale in test
+0507451 [BUILD] Replaced deprecated "weak_vendors" option
+530b31e Added GitHub sponsoring information
+a414694 [PATCH] Fixed CS
+fd7d077 [BUILD] Updated export-ignore files
+e18bf64 [BUILD] Updated build tools
+7f9dab9 [PATCH] Fixed S
+c7fcc13 [BUILD] Removed dependency stage from build matrix
+b3c1e3c [TEST] Fixed tests for old symfony versions
+d7cf491 [TEST] Removed deprecation warning
+c7f65ac [TEST] Increased test coverage
+392f97b [PATCH] Fixed CS
+960e91e [MINOR] Set (Date)OutputType compound to false
+7c69b92 [MINOR] Deprecated DatePickerType
+e7ad3b1 [MINOR] Deprecated class in BatchTimeType constructor
+9eea35d [TEST] Removed hard Form::getData call in FormHandlerTest
+4a2f80c [MINOR] Changed default help_translation_domain to null
+b066fd9 [MINOR] Throw exception when validating invalid model
+47fbbb9 [PATCH] Minor internal code refactoring
+9dd9960 [PATCH] Added FormExtension::getExtendedType method as a symfony BC layer
+65ba957 [MINOR] Deprecated HelpTypeExtension in favor of the symfony "help" extension
+0de2920 [BUILD] Removed current copyright date
+c587559 [BUILD] Cleanup phpstan errors
+8473f61 [PATCH] Fixed BatchTimeAfterValidator for with fields
+575f23b [PATCH] Minor internal code refactoring
+50d94ca [PATCH] Minor internal code refactoring
+5c1865f [BUILD] Fixed phpstan ignore list
+f18e325 [BUILD] Added more tests
+a8fbed6 [MINOR] Fixed wrong form service ids
+04a596c [MINOR] Throw correct exception in constraints
+d824412 [BUILD] Added more tests
 17/03/2019 17:11  2.1.0  Added validator annotations
 c18b7f0 [MINOR] Added validator constraints annotations
 9c71920 [BUILD] Added weak_vendors when calling phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/bootstrap.php">
   <php>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
   </php>
   <testsuites>
     <testsuite name="Form Extensions Test Suite">

--- a/tests/Type/DatePickerTypeTest.php
+++ b/tests/Type/DatePickerTypeTest.php
@@ -25,7 +25,7 @@ class DatePickerTypeTest extends BaseTypeTest
     {
         $this->translator      = $this->prophesize(TranslatorInterface::class);
         $this->translator->getLocale()
-            ->willReturn('EN')
+            ->willReturn('en')
         ;
         $this->formatConverter = $this->prophesize(MomentFormatConverter::class);
 

--- a/tests/Type/DateTimePickerTypeTest.php
+++ b/tests/Type/DateTimePickerTypeTest.php
@@ -24,7 +24,7 @@ class DateTimePickerTypeTest extends BaseTypeTest
     {
         $this->translator      = $this->prophesize(TranslatorInterface::class);
         $this->translator->getLocale()
-            ->willReturn('EN')
+            ->willReturn('en')
         ;
         $this->formatConverter = $this->prophesize(MomentFormatConverter::class);
 


### PR DESCRIPTION
f74947c [TEST] Use better default locale in test
0507451 [BUILD] Replaced deprecated "weak_vendors" option
530b31e Added GitHub sponsoring information
a414694 [PATCH] Fixed CS
fd7d077 [BUILD] Updated export-ignore files
e18bf64 [BUILD] Updated build tools
7f9dab9 [PATCH] Fixed S
c7fcc13 [BUILD] Removed dependency stage from build matrix
b3c1e3c [TEST] Fixed tests for old symfony versions
d7cf491 [TEST] Removed deprecation warning
c7f65ac [TEST] Increased test coverage
392f97b [PATCH] Fixed CS
960e91e [MINOR] Set (Date)OutputType compound to false
7c69b92 [MINOR] Deprecated DatePickerType
e7ad3b1 [MINOR] Deprecated class in BatchTimeType constructor
9eea35d [TEST] Removed hard Form::getData call in FormHandlerTest
4a2f80c [MINOR] Changed default help_translation_domain to null
b066fd9 [MINOR] Throw exception when validating invalid model
47fbbb9 [PATCH] Minor internal code refactoring
9dd9960 [PATCH] Added FormExtension::getExtendedType method as a symfony BC layer
65ba957 [MINOR] Deprecated HelpTypeExtension in favor of the symfony "help" extension
0de2920 [BUILD] Removed current copyright date
c587559 [BUILD] Cleanup phpstan errors
8473f61 [PATCH] Fixed BatchTimeAfterValidator for with fields
575f23b [PATCH] Minor internal code refactoring
50d94ca [PATCH] Minor internal code refactoring
5c1865f [BUILD] Fixed phpstan ignore list
f18e325 [BUILD] Added more tests
a8fbed6 [MINOR] Fixed wrong form service ids
04a596c [MINOR] Throw correct exception in constraints
d824412 [BUILD] Added more tests